### PR TITLE
Update GitHub Actions workflow for Docker build and push

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     
     steps:
       - name: Checkout code
@@ -17,17 +20,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: benjan/weatherapp
+          images: ghcr.io/${{ github.repository_owner }}/weatherapp
           tags: |
             type=ref,event=branch
             type=sha,prefix={{branch}}-
@@ -41,6 +45,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=benjan/weatherapp:buildcache
-          cache-to: type=registry,ref=benjan/weatherapp:buildcache,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/weatherapp:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/weatherapp:buildcache,mode=max
 


### PR DESCRIPTION
- Adjust permissions for the build job to allow reading contents and writing packages
- Change Docker Hub login to GitHub Container Registry
- Update image references to use GitHub Container Registry format